### PR TITLE
fix: remove "use client" from layout.js

### DIFF
--- a/src/DemoStudentDataContext.js
+++ b/src/DemoStudentDataContext.js
@@ -1,3 +1,5 @@
+"use client"
+
 import React, { createContext, useState } from "react"
 import studentData from "./studentData"
 

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,5 +1,3 @@
-"use client"
-
 import './globals.css'
 import { Nunito } from 'next/font/google'
 import { DemoStudentDataProvider } from "../DemoStudentDataContext"


### PR DESCRIPTION
fix: remove "use client" from layout.js - attempting to export "metadata" from a component marked with "use client", is disallowed.