### PR TITLE
fix: forms + style: profile menu dropdown

### DIFF
--- a/src/app/(auth)/forgot-password/_components/PasswordReset.tsx
+++ b/src/app/(auth)/forgot-password/_components/PasswordReset.tsx
@@ -27,7 +27,7 @@ const PasswordReset = () => {
 	}
 
 	return (
-		<div className="w-full max-w-[450px] bg-[#fbe8de] p-5 rounded-lg shadow-xl z-50">
+		<div className="w-full max-w-[450px] bg-[#fbe8de] p-5 rounded-lg shadow-xl z-10">
 			<h1 className="text-3xl md:text-4xl font-bold text-center">
 				Password Reset
 			</h1>

--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -17,11 +17,11 @@ const ForgotPassword = () => {
 		},
 		{
 			src: "/assets/Scribbles/66.svg",
-			className: "absolute top-60 right-16 md:right-80 w-[50px] md:w-[100px]"
+			className: "absolute top-52 right-24 md:right-80 w-[50px] md:w-[100px]"
 		},
 		{
 			src: "/assets/Scribbles/5.svg",
-			className: "absolute bottom-16 left-2 w-[150px] md:w-[200px]"
+			className: "absolute bottom-24 left-2 w-[100px] md:w-[200px]"
 		},
 		{
 			src: "/assets/Scribbles/55.svg",
@@ -64,10 +64,10 @@ const ForgotPassword = () => {
 			<header>
 				<Nav />
 			</header>
-			<main className="py-16 px-10 min-h-screen flex flex-col items-center justify-center relative">
+			<main className="py-24 px-10 min-h-screen flex flex-col items-center justify-center relative">
 				<Scribble scribblesSvgs={scribblesSvgs} />
 				<PasswordReset />
-				<div className="mt-4">
+				<div className="mt-4 z-10">
 					<p>
 						Need an account?{" "}
 						<span>

--- a/src/app/(auth)/login/_components/SignIn.tsx
+++ b/src/app/(auth)/login/_components/SignIn.tsx
@@ -49,7 +49,7 @@ const SignIn = () => {
 	}
 
 	return (
-		<div className="w-full max-w-[450px] bg-[#fbe8de] p-5 rounded-lg shadow-xl z-50">
+		<div className="w-full max-w-[450px] bg-[#fbe8de] p-5 rounded-lg shadow-xl z-10">
 			<h1 className="text-3xl md:text-4xl font-bold text-center">Sign in</h1>
 			{error && (
 				<div className="bg-red-300 text-red-900 font-bold text-center p-3 rounded-md mt-2">
@@ -101,10 +101,10 @@ const SignIn = () => {
 			<p className="text-center text-gray-600 py-5">Or sign in with </p>
 			<button
 				onClick={handleGoogleLogin}
-				className="flex justify-center items-center gap-4 w-full text-primaryTextClr bg-gray-600 p-2 font-medium rounded-lg"
+				className="flex justify-center items-center gap-2 w-full text-primaryTextClr bg-gray-600 p-2 font-medium rounded-lg"
 			>
 				<FcGoogle
-					size={30}
+					size={24}
 					aria-label="/"
 					role="presentation"
 				/>

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -17,20 +17,20 @@ const Login = () => {
 	const scribblesSvgs = [
 		{
 			src: "/assets/Scribbles/67.svg",
-			className: "absolute top-32 left-10 w-[75px] md:w-[150px]"
+			className: "absolute top-28 left-10 w-[75px] md:w-[150px]"
 		},
 		{
 			src: "/assets/Scribbles/37.svg",
 			className:
-				"absolute bottom-32 md:bottom-1 right-20 w-[75px] md:w-[100px] 2xl:w-[150px]"
+				"absolute bottom-20 md:bottom-1 right-20 w-[75px] md:w-[100px] 2xl:w-[150px]"
 		},
 		{
 			src: "/assets/Scribbles/66.svg",
-			className: "absolute top-60 right-16 md:right-80 w-[50px] md:w-[100px]"
+			className: "absolute top-32 right-24 md:right-80 w-[50px] md:w-[100px]"
 		},
 		{
 			src: "/assets/Scribbles/5.svg",
-			className: "absolute bottom-16 left-2 w-[150px] md:w-[200px]"
+			className: "absolute bottom-16 left-2 w-[100px] md:w-[200px]"
 		},
 		{
 			src: "/assets/Scribbles/55.svg",
@@ -81,10 +81,10 @@ const Login = () => {
 			<header>
 				<Nav />
 			</header>
-			<main className="py-16 px-10 min-h-screen flex flex-col items-center justify-center relative">
+			<main className="py-24 px-10 min-h-screen flex flex-col items-center justify-center relative">
 				<Scribble scribblesSvgs={scribblesSvgs} />
 				<SignIn />
-				<div className="mt-4">
+				<div className="mt-4 z-10">
 					<p>
 						Need an account?{" "}
 						<span>

--- a/src/app/(auth)/register/_components/Signup.tsx
+++ b/src/app/(auth)/register/_components/Signup.tsx
@@ -41,7 +41,7 @@ const Signup = () => {
 	}
 
 	return (
-		<div className="w-full max-w-[450px] bg-[#fbe8de] p-5 rounded-lg shadow-xl z-50">
+		<div className="w-full max-w-[450px] bg-[#fbe8de] p-5 rounded-lg shadow-xl z-10">
 			<h1 className="text-3xl md:text-4xl font-bold mb-5 text-center">
 				Sign up
 			</h1>

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -13,15 +13,15 @@ const Register = () => {
 		{
 			src: "/assets/Scribbles/37.svg",
 			className:
-				"absolute bottom-32 md:bottom-1 right-20 w-[75px] md:w-[100px] 2xl:w-[150px]"
+				"absolute bottom-24 md:bottom-1 right-20 w-[75px] md:w-[100px] 2xl:w-[150px]"
 		},
 		{
 			src: "/assets/Scribbles/66.svg",
-			className: "absolute top-60 right-16 md:right-80 w-[50px] md:w-[100px]"
+			className: "absolute top-40 right-24 md:right-80 w-[50px] md:w-[100px]"
 		},
 		{
 			src: "/assets/Scribbles/5.svg",
-			className: "absolute bottom-16 left-2 w-[150px] md:w-[200px]"
+			className: "absolute bottom-16 left-2 w-[100px] md:w-[200px]"
 		},
 		{
 			src: "/assets/Scribbles/55.svg",
@@ -58,15 +58,16 @@ const Register = () => {
 				"hidden 2xl:block absolute right-24 lg:right-80 xl:right-96 w-[50px] rotate-180"
 		}
 	]
+
 	return (
 		<>
 			<header>
 				<Nav />
 			</header>
-			<main className="py-16 px-10 min-h-screen flex flex-col items-center justify-center relative">
+			<main className="py-24 px-10 min-h-screen flex flex-col items-center justify-center relative">
 				<Scribble scribblesSvgs={scribblesSvgs} />
 				<Signup />
-				<div className="mt-4">
+				<div className="mt-4 z-10">
 					<p>
 						Already have an account?{" "}
 						<span>

--- a/src/app/dashboard/_components/ConditionalHeading.tsx
+++ b/src/app/dashboard/_components/ConditionalHeading.tsx
@@ -6,7 +6,7 @@ const ConditionalHeading = () => {
 	const creationTime = currentUser?.metadata.creationTime
 	const lastSignInTime = currentUser?.metadata.lastSignInTime
 	return (
-		<h1 className="text-5xl sm:text-7xl font-cabinSketch font-[700] mb-24">
+		<h1 className="text-5xl sm:text-7xl font-cabinSketch font-[700]">
 			{creationTime === lastSignInTime ? "Welcome!" : "Welcome Back!"}
 		</h1>
 	)

--- a/src/app/dashboard/_components/account/AccountSettings.tsx
+++ b/src/app/dashboard/_components/account/AccountSettings.tsx
@@ -109,7 +109,7 @@ const AccountSettings = ({
 							type="email"
 							defaultValue={currentUser?.email}
 							required
-							className="border-2 border-gray-400 p-3 rounded-md"
+							className="border-2 border-gray-400 p-3 rounded-md text-[#5065a8]"
 						/>
 						<label
 							htmlFor="password"
@@ -123,7 +123,7 @@ const AccountSettings = ({
 							name="password"
 							type="password"
 							placeholder="Leave blank to remain unchanged"
-							className="border-2 border-gray-400 p-3 rounded-md"
+							className="border-2 border-gray-400 p-3 rounded-md text-[#5065a8]"
 						/>
 						<label
 							htmlFor="confirm-password"
@@ -137,7 +137,7 @@ const AccountSettings = ({
 							name="confirm-password"
 							type="password"
 							placeholder="Leave blank to remain unchanged"
-							className="border-2 border-gray-400 p-3 rounded-md"
+							className="border-2 border-gray-400 p-3 rounded-md text-[#5065a8]"
 						/>
 						<button className="mt-4 text-sm font-bold bg-white hover:bg-green-200 rounded-2xl py-3 px-5 disabled:bg-gray-400 disabled:hover:bg-gray-400">
 							Save changes

--- a/src/app/dashboard/_components/account/ProfileMenu.tsx
+++ b/src/app/dashboard/_components/account/ProfileMenu.tsx
@@ -19,7 +19,10 @@ const ProfileMenu = () => {
 				className="inline-block text-left"
 			>
 				<div>
-					<Menu.Button className="flex items-center justify-center w-full bg-transparent text-sm">
+					<Menu.Button
+						className="flex items-center justify-center w-full bg-transparent"
+						aria-label="Profile menu"
+					>
 						<BiSolidUserDetail
 							size={30}
 							className="text-[#5f5f7f]"
@@ -39,37 +42,41 @@ const ProfileMenu = () => {
 					leaveFrom="transform opacity-100 scale-100"
 					leaveTo="transform opacity-0 scale-95"
 				>
-					<Menu.Items className="flex flex-col absolute right-3 w-36 mt-2 p-1 origin-top-right divide-y divide-gray-100 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
-						<Menu.Item>
-							{({ active }) => (
-								<button
-									onClick={handleAccountSettings}
-									className={`${
-										active
-											? "bg-buttonClr text-primaryTextClr"
-											: "text-secondaryTextClr"
-									} group flex w-full items-center rounded-md px-2 py-2`}
-								>
-									Profile settings
-								</button>
-							)}
-						</Menu.Item>
-						<Menu.Item>
-							{({ active }) => (
-								<button
-									onClick={() => {
-										auth.signOut()
-									}}
-									className={`${
-										active
-											? "bg-buttonClr text-primaryTextClr"
-											: "text-secondaryTextClr"
-									} group flex w-full items-center rounded-md px-2 py-2`}
-								>
-									Sign out
-								</button>
-							)}
-						</Menu.Item>
+					<Menu.Items className="flex flex-col absolute right-3 mt-1 w-40 p-1 bg-white rounded-md divide-y divide-grey-100 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
+						<div className="px-1 py-1">
+							<Menu.Item>
+								{({ active }) => (
+									<button
+										onClick={handleAccountSettings}
+										className={`${
+											active
+												? "bg-buttonClr text-primaryTextClr"
+												: "text-secondaryTextClr"
+										} group flex w-full items-center rounded-md px-2 py-2`}
+									>
+										Profile settings
+									</button>
+								)}
+							</Menu.Item>
+						</div>
+						<div className="p-1">
+							<Menu.Item>
+								{({ active }) => (
+									<button
+										onClick={() => {
+											auth.signOut()
+										}}
+										className={`${
+											active
+												? "bg-buttonClr text-primaryTextClr"
+												: "text-secondaryTextClr"
+										} group flex w-full items-center rounded-md px-2 py-2`}
+									>
+										Sign out
+									</button>
+								)}
+							</Menu.Item>
+						</div>
 					</Menu.Items>
 				</Transition>
 			</Menu>

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -36,7 +36,7 @@ const Nav = () => {
 	}
 
 	return (
-		<nav className="fixed top-0 w-full h-[5.5rem] z-[10] px-8 bg-white border-b border-gray-300">
+		<nav className="fixed top-0 w-full h-[5.5rem] px-8 bg-white border-b border-gray-300 z-50">
 			<div className="flex justify-between items-center gap-4 w-full h-full px-2 2xl:px-16">
 				<Logo />
 				{/* Desktop */}

--- a/src/components/classroom/options/Options.tsx
+++ b/src/components/classroom/options/Options.tsx
@@ -65,7 +65,7 @@ const Options = () => {
 					leaveTo="transform opacity-0 scale-95"
 				>
 					<Menu.Items className="absolute right-0 mt-2 w-56 origin-top-right divide-y divide-gray-100 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
-						<div className="px-1 py-1 ">
+						<div className="p-1">
 							<Menu.Item>
 								{({ active }) => (
 									<button
@@ -117,7 +117,7 @@ const Options = () => {
 								)}
 							</Menu.Item>
 						</div>
-						<div className="px-1 py-1">
+						<div className="p-1">
 							<Menu.Item>
 								{({ active }) => (
 									<button


### PR DESCRIPTION
fix: made changes to the z-index of the sign in/up and reset password forms to ensure that they do not cover the nav on page height resize.

style: increased spacing between profile menu options so that the divider between them is more visible.

style: changed email/password input text colour in AccountSettings modal.

accessibility: added aria-label to profile menu btn to improve accessibility.