### PR TITLE
fix: add z index to profile menu

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -49,7 +49,7 @@ const Dashboard = () => {
 				<Nav />
 			</header>
 			<main className="relative py-40 min-h-screen w-full">
-				<div className="fixed top-[5.5rem] flex justify-end items-center px-8 bg-white w-full h-12 border-b border-gray-300">
+				<div className="fixed top-[5.5rem] flex justify-end items-center px-8 bg-white w-full h-12 border-b border-gray-300 z-10">
 					<ProfileMenu />
 				</div>
 				<div className="flex flex-col justify-center items-center text-center px-8">


### PR DESCRIPTION
fix: add z-index: 10; to <ProfileMenu /> component to prevent other components overlapping.

prior to fix: when users would scroll down the dashboard page, the demo class link,  users class links and create class btn would overlap the profile menu div.