### PR TITLE
fix: users can't use back button on dashboard page

### DIFF
--- a/src/app/(auth)/login/_components/SignIn/SignIn.tsx
+++ b/src/app/(auth)/login/_components/SignIn/SignIn.tsx
@@ -4,7 +4,6 @@ import { useAuth } from "@/context/AuthContext"
 import { doc, getDoc, setDoc, serverTimestamp } from "firebase/firestore"
 import { db } from "@/utils/firebase"
 import { FcGoogle } from "react-icons/fc"
-import { useRouter } from "next/navigation"
 import { AuthErrorCodes } from "firebase/auth"
 
 const SignIn = () => {
@@ -13,7 +12,6 @@ const SignIn = () => {
 	const [error, setError] = useState("")
 	const [loading, setLoading] = useState(false)
 	const { login, googleLogin } = useAuth()
-	const router = useRouter()
 
 	const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
 		e.preventDefault()
@@ -36,7 +34,6 @@ const SignIn = () => {
 			setError("")
 			setLoading(true)
 			await login(email, password)
-			router.push("/dashboard")
 		} catch (error) {
 			if (error.code.includes("auth/user-not-found")) {
 				setError("Incorrect email or password")
@@ -45,9 +42,9 @@ const SignIn = () => {
 			} else {
 				setError("Failed to sign in"), error
 			}
+		} finally {
+			setLoading(false)
 		}
-
-		setLoading(false)
 	}
 
 	const handleGoogleLogin = async () => {
@@ -57,7 +54,7 @@ const SignIn = () => {
 			const userDocRef = doc(db, "users", result.user.uid)
 			const docSnap = await getDoc(userDocRef)
 			if (docSnap.exists()) {
-				router.push("/dashboard") // Redirect user to the dashboard
+				// If it exists, return early to avoid creating duplicate records.
 				return
 			}
 			await setDoc(userDocRef, {

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,19 +1,15 @@
 "use client"
 
-import React, { useEffect, useState } from "react"
+import React, { useEffect } from "react"
 import Link from "next/link"
 import { useAuth } from "@/context/AuthContext"
 import Nav from "@/components/Nav"
-import Preloader from "@/components/Preloader"
 import Scribble from "@/components/Scribble"
-import { useRouter } from "next/navigation"
+import { redirect } from "next/navigation"
 import SignIn from "./_components/SignIn/SignIn"
 
 const Login = () => {
-	const [loading, setLoading] = useState(false)
 	const { currentUser } = useAuth()
-	const router = useRouter()
-	// const [loading] = useAuthState(auth)
 	const scribblesSvgs = [
 		{
 			src: "/assets/Scribbles/67.svg",
@@ -70,11 +66,11 @@ const Login = () => {
 
 	useEffect(() => {
 		if (currentUser) {
-			router.push("/dashboard")
+			// 'redirect' by default replaces the sign up page in browser history stack
+			// this allows users to use back button on dashboard to go back to their previous page that isn't the sign up page
+			redirect("/dashboard")
 		}
-	}, [currentUser, router])
-
-	if (loading) return <Preloader />
+	}, [currentUser])
 
 	return (
 		<>

--- a/src/app/(auth)/register/_components/Signup/Signup.tsx
+++ b/src/app/(auth)/register/_components/Signup/Signup.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import React, { useState } from "react"
-import { useRouter } from "next/navigation"
 import { doc, setDoc, serverTimestamp } from "firebase/firestore"
 import { AuthErrorCodes } from "firebase/auth"
 import { db } from "@/utils/firebase"
@@ -14,7 +13,6 @@ const Signup = () => {
 	const [error, setError] = useState("")
 	const [loading, setLoading] = useState(false)
 	const { signup } = useAuth()
-	const router = useRouter()
 
 	const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
 		e.preventDefault()
@@ -37,7 +35,6 @@ const Signup = () => {
 				email: result.user.email,
 				createdAt: serverTimestamp()
 			})
-			router.push("/dashboard")
 		} catch (error) {
 			if (error.code === AuthErrorCodes.EMAIL_EXISTS) {
 				setError("Email address is already registered"), error
@@ -46,9 +43,9 @@ const Signup = () => {
 			} else {
 				setError("Failed to create an account"), error
 			}
+		} finally {
+			setLoading(false)
 		}
-
-		setLoading(false)
 	}
 
 	return (

--- a/src/app/(auth)/register/_components/Signup/__tests__/Signup.test.tsx
+++ b/src/app/(auth)/register/_components/Signup/__tests__/Signup.test.tsx
@@ -4,10 +4,12 @@ import Signup from "../Signup"
 import { AuthProvider } from "@/context/AuthContext"
 import { AppRouterContextProviderMock } from "@/__mocks__/AppRouterContextProviderMock"
 import userEvent from "@testing-library/user-event"
+import { auth } from "@/utils/firebase"
 import {
 	getAuth,
 	createUserWithEmailAndPassword,
-	onAuthStateChanged
+	onAuthStateChanged,
+	AuthErrorCodes
 } from "firebase/auth"
 
 jest.mock("firebase/auth", () => ({
@@ -130,6 +132,13 @@ describe("SignIn", () => {
 		// 	const user = userEvent.setup()
 		// 	renderSignup()
 
+		// 	// Mock the createUserWithEmailAndPassword function to throw a weak password error
+		// 	const mockCreateUserWithEmailAndPassword = jest
+		// 		.fn()
+		// 		.mockResolvedValue(
+		// 			new Error("Password should be at least 6 characters")
+		// 		)
+
 		// 	const emailInput = screen.getByTestId("email-input")
 		// 	const passwordInput = screen.getByTestId("password-input")
 		// 	const confirmPasswordInput = screen.getByTestId("confirm-password-input")
@@ -142,7 +151,16 @@ describe("SignIn", () => {
 		// 	await user.type(confirmPasswordInput, "test")
 		// 	await user.click(signupButtonEl)
 
-		// 	const errorMessageEl = screen.getByTestId("error")
+		// 	await mockCreateUserWithEmailAndPassword("testemail@email.com", "test")
+
+		// 	expect(mockCreateUserWithEmailAndPassword).toHaveBeenCalledWith(
+		// 		"testemail@email.com",
+		// 		"test"
+		// 	)
+		// 	expect(mockCreateUserWithEmailAndPassword).toHaveBeenCalledTimes(1)
+
+		// 	// wait for the error message to be displayed
+		// 	const errorMessageEl = await screen.findByTestId("error")
 		// 	expect(errorMessageEl).toHaveTextContent(
 		// 		/password should be at least 6 characters/i
 		// 	)
@@ -234,5 +252,29 @@ describe("SignIn", () => {
 
 			expect(signupButtonEl).toBeEnabled()
 		})
+
+		//TODO:
+		// it("should register a user", async () => {
+		// 	const user = userEvent.setup()
+		// 	renderSignup()
+
+		// 	const emailInput = screen.getByTestId("email-input")
+		// 	const passwordInput = screen.getByTestId("password-input")
+		// 	const confirmPasswordInput = screen.getByTestId("confirm-password-input")
+		// 	const signupButtonEl = screen.getByRole("button", {
+		// 		name: /sign up/i
+		// 	})
+
+		// 	await user.type(emailInput, "testemail@email.com")
+		// 	await user.type(passwordInput, "testpassword")
+		// 	await user.type(confirmPasswordInput, "testpassword")
+		// 	await user.click(signupButtonEl)
+
+		// 	expect(createUserWithEmailAndPassword).toBeCalledWith(
+		// 		auth,
+		// 		"testemail@email.com",
+		// 		"testpassword"
+		// 	)
+		// })
 	})
 })

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -1,10 +1,15 @@
-import React from "react"
+"use client"
+
+import React, { useEffect } from "react"
 import Link from "next/link"
+import { redirect } from "next/navigation"
+import { useAuth } from "@/context/AuthContext"
 import Signup from "@/app/(auth)/register/_components/Signup/Signup"
 import Nav from "@/components/Nav"
 import Scribble from "@/components/Scribble"
 
 const Register = () => {
+	const { currentUser } = useAuth()
 	const scribblesSvgs = [
 		{
 			src: "/assets/Scribbles/67.svg",
@@ -58,6 +63,14 @@ const Register = () => {
 				"hidden 2xl:block absolute right-24 lg:right-80 xl:right-96 w-[50px] rotate-180"
 		}
 	]
+
+	useEffect(() => {
+		if (currentUser) {
+			// 'redirect' by default replaces the sign in page in browser history stack
+			// this allows users to use back button on dashboard to go back to their previous page that isn't the sign in page
+			redirect("/dashboard")
+		}
+	}, [currentUser])
 
 	return (
 		<>


### PR DESCRIPTION
fix: users can now use the back button on the dashboard page when signing up/in to return back to their previous page before the sign up or sign in page.

prior to fix: when a user would press back whilst on the dashboard, it would try and redirect them back to the sign up or sign in page and then redirect them back to the dashboard

In order to replace the sign up/sign in page in the browser history stack, I refactored the sign up/sign in page to use 'redirect()' instead of 'router.push()'. This is because by default in client components, redirect will replace the current URL in the browser history stack.

This fix/refactor creates a better UX and improves the users ability to navigate around the app.