### PR TITLE
fix: error from unauthenticated user accessing democlass page

### DIFF
--- a/src/components/classroom/toolbar/TaskList.tsx
+++ b/src/components/classroom/toolbar/TaskList.tsx
@@ -58,13 +58,13 @@ const TaskList = ({
 		} catch (error) {
 			console.error("Error fetching task list data from Firestore:", error)
 		}
-	}, [params.classroom_id, currentUser.uid])
+	}, [params.classroom_id, currentUser?.uid])
 
 	useEffect(() => {
-		if (currentUser.uid && params.classroom_id) {
+		if (currentUser?.uid && params.classroom_id) {
 			fetchTaskListData()
 		}
-	}, [currentUser.uid, params.classroom_id, fetchTaskListData])
+	}, [currentUser?.uid, params.classroom_id, fetchTaskListData])
 
 	const handleSubmit = async (e: React.SyntheticEvent) => {
 		e.preventDefault()

--- a/src/components/classroom/toolbar/instructions/Instructions.tsx
+++ b/src/components/classroom/toolbar/instructions/Instructions.tsx
@@ -156,14 +156,14 @@ const Instructions = ({
 		} catch (error) {
 			console.error("Error fetching instructions data from Firestore:", error)
 		}
-	}, [params.classroom_id, currentUser.uid])
+	}, [params.classroom_id, currentUser?.uid])
 
 	// Fetch the user's instructions data from the Firestore subcollection when currentUser.uid and className are available
 	useEffect(() => {
-		if (currentUser.uid && params.classroom_id) {
+		if (currentUser?.uid && params.classroom_id) {
 			fetchInstructionData()
 		}
-	}, [currentUser.uid, params.classroom_id, fetchInstructionData])
+	}, [currentUser?.uid, params.classroom_id, fetchInstructionData])
 
 	// Displaying instructions + saving them
 	const displayInstructions = () => {


### PR DESCRIPTION
fix: if an unauthenticated user tries to access the democlass page through the URL pathname (/democlass) it will now not throw an error and instead redirect them to the sign in page.

prior to fix: an error would be thrown stating that the currentUser.uid was null.

I implemented the optional chaining operator (?.) on the currentUser.uid in the components where the error was being thrown.