### PR TITLE
fix: prevent instructions overflow

### DIFF
--- a/src/components/classroom/toolbar/instructions/DisplayInstructions.tsx
+++ b/src/components/classroom/toolbar/instructions/DisplayInstructions.tsx
@@ -29,7 +29,7 @@ const DisplayInstructions = ({
 
 			{/* Full-screen container to center the panel */}
 			<div className="fixed inset-0 flex items-center justify-center p-4">
-				<Dialog.Panel className="p-2 sm:p-5 md:p-10 w-full h-full rounded-xl bg-blue-100 border-[20px] md:border-[50px] border-blue-400">
+				<Dialog.Panel className="p-2 sm:p-5 md:p-10 w-full h-full rounded-xl bg-blue-100 border-[20px] md:border-[50px] border-blue-400 overflow-auto">
 					<div className="flex justify-between items-center">
 						<Dialog.Title className="font-bold text-3xl sm:text-5xl md:text-6xl">
 							{instructionTitle}

--- a/src/components/classroom/toolbar/instructions/DisplaySavedInstructions.tsx
+++ b/src/components/classroom/toolbar/instructions/DisplaySavedInstructions.tsx
@@ -29,7 +29,7 @@ const DisplaySavedInstructions = ({
 
 			{/* Full-screen container to center the panel */}
 			<div className="fixed inset-0 flex items-center justify-center p-4">
-				<Dialog.Panel className="p-2 sm:p-5 md:p-10 w-full h-full rounded-xl bg-blue-100 border-[20px] md:border-[50px] border-blue-400">
+				<Dialog.Panel className="p-2 sm:p-5 md:p-10 w-full h-full rounded-xl bg-blue-100 border-[20px] md:border-[50px] border-blue-400 overflow-auto">
 					<div className="flex justify-between items-center p-4">
 						<Dialog.Title className="font-bold text-3xl sm:text-5xl md:text-6xl">
 							{savedInstruction.title}


### PR DESCRIPTION
fix: prevented the instructions from overflowing its container by adding overflow-auto to the dialog panel. Users will have the ability to scroll down if they add more than 8 instructions.

prior to fix: if a user added more than 8 instructions, they would overflow out of the dialog container and would not be visible.