### PR TITLE
fix: input text overflowing containers

### DIFF
--- a/src/app/dashboard/_components/CreateClass.tsx
+++ b/src/app/dashboard/_components/CreateClass.tsx
@@ -124,7 +124,7 @@ function CreateClass({ setShouldFetchClassData }: CreateClassProps) {
 									id="classname"
 									name="classname"
 									required
-									maxLength={25}
+									maxLength={30}
 									className="py-3 px-2 rounded-lg outline-inputOutlineClr"
 								/>
 							</div>

--- a/src/app/dashboard/_components/UsersClasses.tsx
+++ b/src/app/dashboard/_components/UsersClasses.tsx
@@ -56,9 +56,9 @@ const UsersClasses = ({
 								width={100}
 								height={100}
 							/>
-							<h2 className="text-4xl font-cabinSketch font-[400]">
-								{userClass.className.length > 12
-									? `${userClass.className.slice(0, 12)}...`
+							<h2 className="text-3xl font-cabinSketch font-[400]">
+								{userClass.className.length > 9
+									? `${userClass.className.slice(0, 9)}...`
 									: userClass.className}
 							</h2>
 						</div>

--- a/src/app/dashboard/_components/editClass/EditClass.tsx
+++ b/src/app/dashboard/_components/editClass/EditClass.tsx
@@ -101,7 +101,7 @@ const EditClass = ({
 			<div className="fixed inset-0 flex items-center justify-center p-4">
 				<Dialog.Panel className="w-full max-w-[500px] h-full max-h-[465px] min-h-[30vh] rounded-xl bg-modalBgClr border-2 border-modalBorderClr overflow-auto">
 					<div className="p-5 flex justify-between items-center border-b-2 border-gray-300 mb-10">
-						<Dialog.Title className="font-bold text-xl">
+						<Dialog.Title className="font-bold text-xl w-3/4 break-words">
 							Edit {userClassName}
 						</Dialog.Title>
 						<button
@@ -142,6 +142,7 @@ const EditClass = ({
 							value={userClassName}
 							onChange={updateClassName}
 							required
+							maxLength={30}
 						/>
 					</form>
 					<div className="flex flex-row-reverse justify-between items-center border-t-2 border-gray-300 w-full px-5 py-3 mt-24">

--- a/src/components/classroom/Greeting.tsx
+++ b/src/components/classroom/Greeting.tsx
@@ -39,7 +39,7 @@ const Greeting = ({ classData }: GreetingProps) => {
 	}, [classData, params.classroom_id, currentTime, getCurrentUsersClass])
 
 	return (
-		<h1 className="text-5xl sm:text-6xl md:text-7xl text-center font-cabinSketch font-[700]">
+		<h1 className="text-5xl sm:text-6xl md:text-7xl text-center font-cabinSketch font-[700] break-words w-full">
 			{greeting}
 		</h1>
 	)

--- a/src/components/classroom/options/editStudents/EditStudents.tsx
+++ b/src/components/classroom/options/editStudents/EditStudents.tsx
@@ -78,7 +78,7 @@ const EditStudents = ({
 								<button
 									key={student.uuid}
 									onClick={() => handleStudentInfoModal(student)}
-									className="flex flex-col justify-center items-center text-center text-lg border border-buttonClr font-bold bg-white p-3 rounded-xl hover:scale-105 duration-300 break-words"
+									className="flex flex-col justify-center items-center text-center text-lg border border-buttonClr font-bold bg-white p-3 rounded-xl hover:scale-105 duration-300"
 								>
 									<Image
 										src={student.avatar}
@@ -87,7 +87,11 @@ const EditStudents = ({
 										height={40}
 										className="select-none"
 									/>
-									{student.name}
+									<span className="">
+										{student.name.length > 9
+											? student.name.slice(0, 9) + "..."
+											: student.name}
+									</span>
 								</button>
 							))}
 						</div>

--- a/src/components/classroom/options/editStudents/StudentInfoModal.tsx
+++ b/src/components/classroom/options/editStudents/StudentInfoModal.tsx
@@ -118,7 +118,7 @@ const StudentInfoModal = ({
 			<div className="fixed inset-0 flex items-center justify-center p-4">
 				<Dialog.Panel className="flex flex-col w-full max-w-[500px] h-full max-h-[490px] rounded-xl bg-modalBgClr border-2 border-modalBorderClr overflow-auto">
 					<div className="p-5 flex justify-between items-center border-b-2 border-gray-300 z-10">
-						<Dialog.Title className="font-bold text-xl">
+						<Dialog.Title className="font-bold text-xl break-words w-3/4">
 							{selectedStudent?.name}
 						</Dialog.Title>
 						<button
@@ -168,6 +168,7 @@ const StudentInfoModal = ({
 								required
 								value={selectedStudent?.name}
 								onChange={updateStudentName}
+								maxLength={30}
 							/>
 						</div>
 						<div className="flex flex-col">

--- a/src/components/classroom/options/editTables/EditTables.tsx
+++ b/src/components/classroom/options/editTables/EditTables.tsx
@@ -78,7 +78,9 @@ const EditTables = ({
 									onClick={() => handleTableModal(tableName)}
 									className="text-center text-lg border border-buttonClr bg-white p-4 rounded-xl hover:scale-105 duration-300 break-words"
 								>
-									{tableName}
+									{tableName.length > 9
+										? tableName.slice(0, 9) + "..."
+										: tableName}
 								</button>
 							))}
 						</div>

--- a/src/components/classroom/options/editTables/TableInfoModal.tsx
+++ b/src/components/classroom/options/editTables/TableInfoModal.tsx
@@ -125,7 +125,7 @@ const TableInfoModal = ({
 			<div className="fixed inset-0 flex items-center justify-center p-4">
 				<Dialog.Panel className="flex flex-col w-full max-w-[750px] h-full max-h-[500px] rounded-xl bg-modalBgClr border-2 border-modalBorderClr">
 					<div className="p-5 flex justify-between items-center border-b-2 border-gray-300">
-						<Dialog.Title className="font-bold text-xl">
+						<Dialog.Title className="font-bold text-xl break-words w-3/4">
 							{selectedTableName}
 						</Dialog.Title>
 						<button
@@ -167,7 +167,7 @@ const TableInfoModal = ({
 							value={tempSelectedTableName}
 							onChange={updateTableName}
 							type="text"
-							maxLength={20}
+							maxLength={30}
 						/>
 
 						<div className="grid grid-cols-[repeat(auto-fill,minmax(120px,1fr))] gap-4 items-center py-4">
@@ -201,7 +201,9 @@ const TableInfoModal = ({
 												className="select-none"
 											/>
 											<span className="font-bold mt-1 text-lg">
-												{student.name}
+												{student.name.length > 9
+													? student.name.slice(0, 9) + "..."
+													: student.name}
 											</span>
 										</label>
 									</div>

--- a/src/components/classroom/options/resetPoints/ResetStudentPoints.tsx
+++ b/src/components/classroom/options/resetPoints/ResetStudentPoints.tsx
@@ -120,7 +120,7 @@ const ResetStudentPoints = ({
 
 			{/* Full-screen container to center the panel */}
 			<div className="fixed inset-0 flex items-center justify-center p-4">
-				<Dialog.Panel className="flex flex-col justify-between w-full max-w-[800px] h-full max-h-[1000px] rounded-xl bg-modalBgClr border-2 border-modalBorderClr">
+				<Dialog.Panel className="flex flex-col w-full max-w-[800px] h-full max-h-[1000px] rounded-xl bg-modalBgClr border-2 border-modalBorderClr">
 					<div className="p-5 flex justify-between items-center border-b-2 border-gray-300">
 						<Dialog.Title className="font-bold text-xl">
 							Reset Points
@@ -169,39 +169,43 @@ const ResetStudentPoints = ({
 					</Dialog.Description>
 					{studentView ? (
 						<>
-							<div className="grid grid-cols-[repeat(auto-fill,minmax(120px,1fr))] overflow-auto h-[600px] p-5">
-								{studentData.map((student) => (
-									<div
-										key={student.uuid}
-										className="mx-auto h-fit my-2"
-									>
-										<input
-											onChange={toggleSelectedStudent}
-											type="checkbox"
-											id={student.name}
-											name={student.name}
-											checked={student.selected}
-											className="hidden peer"
-										/>
-										<label
-											htmlFor={student.name}
-											className="flex flex-col items-center w-28 cursor-pointer text-center bg-white border border-buttonClr p-4 rounded-xl peer-checked:bg-green-200 peer-hover:scale-105 duration-300 select-none"
+							<div className="h-full overflow-auto">
+								<div className="grid grid-cols-[repeat(auto-fill,minmax(120px,1fr))] p-5">
+									{studentData.map((student) => (
+										<div
+											key={student.uuid}
+											className="mx-auto h-fit my-2"
 										>
-											<Image
-												src={student.avatar}
-												alt="/"
-												width={40}
-												height={40}
-												className="select-none"
+											<input
+												onChange={toggleSelectedStudent}
+												type="checkbox"
+												id={student.name}
+												name={student.name}
+												checked={student.selected}
+												className="hidden peer"
 											/>
-											<span className="font-bold mt-1 text-lg">
-												{student.name}
-											</span>
-										</label>
-									</div>
-								))}
+											<label
+												htmlFor={student.name}
+												className="flex flex-col items-center w-[7.3rem] cursor-pointer text-center bg-white border border-buttonClr p-4 rounded-xl peer-checked:bg-green-200 peer-hover:scale-105 duration-300 select-none"
+											>
+												<Image
+													src={student.avatar}
+													alt="/"
+													width={40}
+													height={40}
+													className="select-none"
+												/>
+												<span className="font-bold mt-1 text-lg">
+													{student.name.length > 9
+														? student.name.slice(0, 9) + "..."
+														: student.name}
+												</span>
+											</label>
+										</div>
+									))}
+								</div>
 							</div>
-							<div className="flex flex-row justify-end items-center text-sm border-t-2 border-gray-300 px-5 py-3">
+							<div className="flex justify-end items-center text-sm border-t-2 border-gray-300 px-5 py-3">
 								{areAllStudentsSelected ? (
 									<button
 										onClick={deselectAllStudents}

--- a/src/components/classroom/options/resetPoints/ResetTablePoints.tsx
+++ b/src/components/classroom/options/resetPoints/ResetTablePoints.tsx
@@ -118,30 +118,34 @@ const ResetTablePoints = ({
 
 	return (
 		<>
-			<div className="grid grid-cols-[repeat(auto-fill,minmax(130px,1fr))] gap-1 overflow-auto h-[600px] p-5">
-				{tables.map((table) => (
-					<div
-						key={table.tableName}
-						className="mx-auto h-fit my-2"
-					>
-						<input
-							onChange={toggleSelectedTable}
-							type="checkbox"
-							id={table.tableName}
-							name={table.tableName}
-							checked={table.selected}
-							className="hidden peer"
-						/>
-						<label
-							htmlFor={table.tableName}
-							className="flex flex-col justify-center items-center h-20 w-32 cursor-pointer text-center font-bold text-lg bg-white p-4 border border-buttonClr rounded-xl peer-checked:bg-green-200 peer-hover:scale-105 duration-300 select-none"
+			<div className="h-full overflow-auto">
+				<div className="grid grid-cols-[repeat(auto-fill,minmax(130px,1fr))] p-5">
+					{tables.map((table) => (
+						<div
+							key={table.tableName}
+							className="mx-auto h-fit my-2"
 						>
-							{table.tableName}
-						</label>
-					</div>
-				))}
+							<input
+								onChange={toggleSelectedTable}
+								type="checkbox"
+								id={table.tableName}
+								name={table.tableName}
+								checked={table.selected}
+								className="hidden peer"
+							/>
+							<label
+								htmlFor={table.tableName}
+								className="flex flex-col justify-center items-center h-20 w-32 cursor-pointer text-center font-bold text-lg bg-white p-4 border border-buttonClr rounded-xl peer-checked:bg-green-200 peer-hover:scale-105 duration-300 select-none"
+							>
+								{table.tableName.length > 9
+									? table.tableName.slice(0, 9) + "..."
+									: table.tableName}
+							</label>
+						</div>
+					))}
+				</div>
 			</div>
-			<div className="flex flex-row justify-end items-center text-sm border-t-2 border-gray-300 px-5 py-3">
+			<div className="flex justify-end items-center text-sm border-t-2 border-gray-300 px-5 py-3">
 				{areAllTablesSelected ? (
 					<button
 						onClick={deselectAllTables}

--- a/src/components/classroom/studentGrid/AddStudent.tsx
+++ b/src/components/classroom/studentGrid/AddStudent.tsx
@@ -193,6 +193,7 @@ const AddStudent = ({
 									id="name"
 									name="name"
 									ref={nameInputRef}
+									maxLength={30}
 								/>
 								<div className="flex items-center gap-2 pt-4 relative">
 									<label htmlFor="dob">{`Date of birth (optional or add later)`}</label>

--- a/src/components/classroom/studentGrid/CopyPasteStudentList.tsx
+++ b/src/components/classroom/studentGrid/CopyPasteStudentList.tsx
@@ -65,6 +65,10 @@ const CopyPasteStudentList = ({
 		)
 	}
 
+	const checkForTooLongName = (namesToCheck: string[]) => {
+		return namesToCheck.some((student) => student.length > 30)
+	}
+
 	const handleAddPastedStudents = () => {
 		const validStudentNames = extractValidStudentNames(pastedText)
 
@@ -88,11 +92,18 @@ const CopyPasteStudentList = ({
 			}
 		})
 
+		const isNameTooLong = checkForTooLongName(validStudentNames)
+
 		const isDuplicate = checkForDuplicates(
 			validStudentNames,
 			addedStudents,
 			studentData
 		)
+
+		if (isNameTooLong) {
+			setAlertMessage("Please enter a first name with 30 letters or fewer")
+			return
+		}
 
 		if (isDuplicate) {
 			setAlertMessage(

--- a/src/components/classroom/studentGrid/StudentCard.tsx
+++ b/src/components/classroom/studentGrid/StudentCard.tsx
@@ -127,7 +127,11 @@ const StudentCard = ({ avatars, setShowConfetti }: StudentCardProps) => {
 					key={student.uuid}
 					className="relative flex flex-col justify-center items-center p-8 shadow-lg rounded-md bg-[#f5f5f5]"
 				>
-					<p className="font-bold tracking-wide text-center">{student.name}</p>
+					<p className="font-bold tracking-wide text-center">
+						{student.name.length > 9
+							? student.name.slice(0, 9) + "..."
+							: student.name}
+					</p>
 					<p className="text-center text-primaryTextClr w-[50px] p-2 bg-iconClr rounded-lg mx-auto my-1">
 						{student.points}
 					</p>

--- a/src/components/classroom/tableGrid/AddTable.tsx
+++ b/src/components/classroom/tableGrid/AddTable.tsx
@@ -183,7 +183,7 @@ const AddTable = ({
 									id="tableName"
 									name="tableName"
 									required
-									maxLength={20}
+									maxLength={30}
 									ref={tableInputRef}
 									className={
 										alertMessage
@@ -209,7 +209,7 @@ const AddTable = ({
 										/>
 										<label
 											htmlFor={student.name}
-											className="flex flex-col items-center w-28 cursor-pointer text-center bg-white border border-buttonClr p-4 rounded-xl peer-disabled:bg-gray-200 peer-checked:bg-green-200 peer-hover:scale-105 duration-300 select-none"
+											className="flex flex-col items-center w-[7.3rem] cursor-pointer text-center bg-white border border-buttonClr p-4 rounded-xl peer-disabled:bg-gray-200 peer-checked:bg-green-200 peer-hover:scale-105 duration-300 select-none"
 										>
 											<Image
 												src={student.avatar}
@@ -219,9 +219,15 @@ const AddTable = ({
 												className="select-none"
 											/>
 											<span className="font-bold mt-1 text-lg">
-												{student.name}
+												{student.name.length > 9
+													? student.name.slice(0, 9) + "..."
+													: student.name}
 											</span>
-											<span>{student.tableData.tableName}</span>
+											<span>
+												{student.tableData.tableName.length > 9
+													? student.tableData.tableName.slice(0, 9) + "..."
+													: student.tableData.tableName}
+											</span>
 										</label>
 									</div>
 								))}

--- a/src/components/classroom/tableGrid/TableCard.tsx
+++ b/src/components/classroom/tableGrid/TableCard.tsx
@@ -63,9 +63,11 @@ const TableCard = ({ groupedStudentsByTable }: TableCardProps) => {
 			{Object.entries(groupedStudentsByTable).map(([tableName, students]) => (
 				<div
 					key={tableName}
-					className="relative flex flex-col justify-between items-center h-[270px] p-8 shadow-lg rounded-md bg-[#f5f5f5]"
+					className="relative flex flex-col justify-between items-center text-center h-[270px] p-8 shadow-lg rounded-md bg-[#f5f5f5]"
 				>
-					<h2 className="font-bold tracking-wide text-2xl">{tableName}</h2>
+					<p className="font-bold tracking-wide text-2xl w-full break-words md:w-auto">
+						{tableName.length > 18 ? tableName.slice(0, 18) + "..." : tableName}
+					</p>
 					<p className="text-center text-primaryTextClr text-xl w-[50px] p-2 bg-iconClr rounded-lg mx-auto my-1">
 						{/* assume that all students in the same table have the same number of points, so render points of the first student only */}
 						{students[0].tableData?.tablePoints || 0}

--- a/src/components/classroom/toolbar/Randomiser.tsx
+++ b/src/components/classroom/toolbar/Randomiser.tsx
@@ -136,7 +136,9 @@ const Randomiser = ({ openRandomiser, setOpenRandomiser }: RandomiserProps) => {
 								{randomStudent ? (
 									<>
 										<p className="font-bold text-3xl tracking-wide">
-											{randomStudent.name}
+											{randomStudent.name.length > 9
+												? randomStudent.name.slice(0, 9) + "..."
+												: randomStudent.name}
 										</p>
 										<p className="text-center text-primaryTextClr text-2xl w-[60px] p-2 bg-iconClr rounded-lg mx-auto my-1">
 											{randomStudent.points}

--- a/src/components/classroom/toolbar/TaskList.tsx
+++ b/src/components/classroom/toolbar/TaskList.tsx
@@ -31,23 +31,25 @@ const TaskList = ({
 	const inputRef = useRef<HTMLInputElement>(null)
 
 	useEffect(() => {
-		const loadTaskListData = async () => {
-			try {
-				const taskListData = await fetchTaskListData(
-					currentUser,
-					params.classroom_id
-				)
+		if (params.classroom_id) {
+			const loadTaskListData = async () => {
+				try {
+					const taskListData = await fetchTaskListData(
+						currentUser,
+						params.classroom_id
+					)
 
-				if (Array.isArray(taskListData)) {
-					setTasks(taskListData)
-				} else {
-					console.error("taskListData is not an array or is undefined.")
+					if (Array.isArray(taskListData)) {
+						setTasks(taskListData)
+					} else {
+						console.error("taskListData is not an array or is undefined.")
+					}
+				} catch (error) {
+					console.error("Error fetching task list data from Firestore:", error)
 				}
-			} catch (error) {
-				console.error("Error fetching task list data from Firestore:", error)
 			}
+			loadTaskListData()
 		}
-		loadTaskListData()
 	}, [currentUser, params.classroom_id])
 
 	const handleSubmit = async (e: React.SyntheticEvent) => {
@@ -208,14 +210,12 @@ const TaskList = ({
 							return (
 								<li
 									key={task.id}
-									className="flex justify-between items-center"
+									className="flex justify-between items-center gap-5"
 								>
 									<label
-										className={
-											task.completed
-												? "text-lg text-gray-400 flex gap-2"
-												: "text-lg flex gap-2"
-										}
+										className={`text-lg flex gap-2 w-3/4 ${
+											task.completed ? "text-gray-400" : ""
+										}`}
 									>
 										<input
 											type="checkbox"
@@ -225,7 +225,7 @@ const TaskList = ({
 											}
 											className="w-4"
 										/>
-										{task.title}
+										<span className="w-full break-words">{task.title}</span>
 									</label>
 									<button
 										onClick={() => deleteTask(task.id)}

--- a/src/components/classroom/toolbar/instructions/DisplayInstructions.tsx
+++ b/src/components/classroom/toolbar/instructions/DisplayInstructions.tsx
@@ -31,7 +31,7 @@ const DisplayInstructions = ({
 			<div className="fixed inset-0 flex items-center justify-center p-4">
 				<Dialog.Panel className="p-2 sm:p-5 md:p-10 w-full h-full rounded-xl bg-blue-100 border-[20px] md:border-[50px] border-blue-400 overflow-auto">
 					<div className="flex justify-between items-center">
-						<Dialog.Title className="font-bold text-3xl sm:text-5xl md:text-6xl">
+						<Dialog.Title className="font-bold text-3xl sm:text-5xl md:text-6xl w-[95%] break-words">
 							{instructionTitle}
 						</Dialog.Title>
 						<button onClick={() => setOpenInstructions(false)}>
@@ -45,7 +45,7 @@ const DisplayInstructions = ({
 						{instructionsList.map((instruction, index) => (
 							<p
 								key={index}
-								className="text-3xl sm:text-4xl md:text-5xl mb-10"
+								className="text-3xl sm:text-4xl md:text-5xl mb-10 w-full break-words"
 							>
 								{`${index + 1}. ${instruction}`}
 							</p>

--- a/src/components/classroom/toolbar/instructions/DisplaySavedInstructions.tsx
+++ b/src/components/classroom/toolbar/instructions/DisplaySavedInstructions.tsx
@@ -31,7 +31,7 @@ const DisplaySavedInstructions = ({
 			<div className="fixed inset-0 flex items-center justify-center p-4">
 				<Dialog.Panel className="p-2 sm:p-5 md:p-10 w-full h-full rounded-xl bg-blue-100 border-[20px] md:border-[50px] border-blue-400 overflow-auto">
 					<div className="flex justify-between items-center p-4">
-						<Dialog.Title className="font-bold text-3xl sm:text-5xl md:text-6xl">
+						<Dialog.Title className="font-bold text-3xl sm:text-5xl md:text-6xl w-[95%] break-words">
 							{savedInstruction.title}
 						</Dialog.Title>
 						<button onClick={() => setOpenInstructions(false)}>
@@ -45,7 +45,7 @@ const DisplaySavedInstructions = ({
 						{savedInstruction.instructions.map((instruction, index) => (
 							<p
 								key={index}
-								className="text-3xl sm:text-4xl md:text-5xl mb-10"
+								className="text-3xl sm:text-4xl md:text-5xl mb-10 w-full break-words"
 							>
 								{`${index + 1}. ${instruction}`}
 							</p>

--- a/src/components/classroom/toolbar/instructions/EditSavedInstructions.tsx
+++ b/src/components/classroom/toolbar/instructions/EditSavedInstructions.tsx
@@ -188,7 +188,7 @@ const EditSavedInstructions = ({
 						>
 							<AiOutlineArrowLeft size={25} />
 						</button>
-						<Dialog.Title className="font-bold text-xl text-center">
+						<Dialog.Title className="font-bold text-xl text-center w-3/4 break-words">
 							Edit {savedInstruction.title}
 						</Dialog.Title>
 						<button onClick={() => setOpenInstructions(false)}>
@@ -234,9 +234,9 @@ const EditSavedInstructions = ({
 								(instruction, instructionIndex) => (
 									<div
 										key={instructionIndex}
-										className="flex justify-between items-center w-full bg-white border-2 border-black rounded-lg p-3 mb-2"
+										className="flex justify-between items-center w-full bg-white border-2 border-black rounded-lg p-3 mb-2 px-3"
 									>
-										<p className="text-lg">{`${
+										<p className="text-lg w-[90%] break-words">{`${
 											instructionIndex + 1
 										}. ${instruction}`}</p>
 										<button

--- a/src/components/classroom/toolbar/instructions/Instructions.tsx
+++ b/src/components/classroom/toolbar/instructions/Instructions.tsx
@@ -50,23 +50,28 @@ const Instructions = ({
 	const { currentUser } = useAuth()
 
 	useEffect(() => {
-		const loadInstructionData = async () => {
-			try {
-				const instructionsData = await fetchIntructionData(
-					currentUser,
-					params.classroom_id
-				)
+		if (params.classroom_id) {
+			const loadInstructionData = async () => {
+				try {
+					const instructionsData = await fetchIntructionData(
+						currentUser,
+						params.classroom_id
+					)
 
-				if (Array.isArray(instructionsData)) {
-					setSavedInstructions(instructionsData)
-				} else {
-					console.error("instructionsData is not an array or is undefined.")
+					if (Array.isArray(instructionsData)) {
+						setSavedInstructions(instructionsData)
+					} else {
+						console.error("instructionsData is not an array or is undefined.")
+					}
+				} catch (error) {
+					console.error(
+						"Error fetching instructions data from Firestore:",
+						error
+					)
 				}
-			} catch (error) {
-				console.error("Error fetching instructions data from Firestore:", error)
 			}
+			loadInstructionData()
 		}
-		loadInstructionData()
 	}, [currentUser, params.classroom_id])
 
 	// Handlers for opening and closing modals
@@ -233,6 +238,7 @@ const Instructions = ({
 								className="p-4 w-full rounded-lg"
 								value={instructionTitle}
 								onChange={(e) => setInstructionTitle(e.target.value)}
+								maxLength={50}
 							/>
 						</div>
 						<button
@@ -248,7 +254,9 @@ const Instructions = ({
 									key={index}
 									className="flex justify-between items-center bg-white border-2 border-black rounded-lg p-3 mb-2"
 								>
-									<p className="text-lg">{`${index + 1}. ${instruction}`}</p>
+									<p className="text-lg w-[90%] break-words">{`${
+										index + 1
+									}. ${instruction}`}</p>
 									<button onClick={() => removeInstruction(index)}>
 										<AiOutlineClose size={25} />
 									</button>
@@ -342,7 +350,9 @@ const Instructions = ({
 												onClick={() => displaySavedInstructions(index)}
 												className="p-4 border-2 border-gray-400 bg-white w-full text-lg rounded-lg mt-4"
 											>
-												{savedInstruction.title}
+												{savedInstruction.title.length > 16
+													? savedInstruction.title.slice(0, 16) + "..."
+													: savedInstruction.title}
 											</button>
 
 											<button


### PR DESCRIPTION
fix: ensured that input text does not overflow its container by:
- setting max length on class name/student first name and table group name to 30
- setting max length on instructions title to 50
- using .slice() to limit the amount of characters shown when a value exceeds a certain length
- use tailwind class 'break-words' to ensure text wraps down onto the next line if there is not enough space

This fix guarantees the stability of the UI, no matter how many characters users input into the input fields.