### PR TITLE
fix: remove ability to add duplicate names

### DIFF
--- a/src/components/classroom/options/editStudents/StudentInfoModal.tsx
+++ b/src/components/classroom/options/editStudents/StudentInfoModal.tsx
@@ -45,11 +45,15 @@ const StudentInfoModal = ({
 		}))
 	}
 
-	const capitaliseStudentName = () => {
-		const updatedCapitalisedName =
-			selectedStudent?.name.charAt(0).toUpperCase() +
-			selectedStudent?.name.slice(1)
-		return updatedCapitalisedName
+	const formatStudentName = () => {
+		const parts = selectedStudent?.name.split(" ")
+		const formattedParts = parts.map((part) => {
+			if (part) {
+				return part.charAt(0).toUpperCase() + part.slice(1).toLowerCase()
+			}
+			return part
+		})
+		return formattedParts.join(" ").trim()
 	}
 
 	const handleStudentInfoSubmit = async (
@@ -57,12 +61,10 @@ const StudentInfoModal = ({
 	) => {
 		try {
 			e.preventDefault()
-
-			capitaliseStudentName()
 			const updatedDob = selectedStudent?.dob
 
 			const existingStudent = studentData.find(
-				(student) => student.name === capitaliseStudentName()
+				(student) => student.name === formatStudentName()
 			)
 
 			if (existingStudent && existingStudent.uuid !== selectedStudent?.uuid) {
@@ -75,7 +77,7 @@ const StudentInfoModal = ({
 				if (student.uuid === selectedStudent?.uuid) {
 					return {
 						...student,
-						name: capitaliseStudentName(),
+						name: formatStudentName(),
 						dob: updatedDob,
 						avatar: newStudentAvatar
 					}

--- a/src/components/classroom/options/editTables/TableInfoModal.tsx
+++ b/src/components/classroom/options/editTables/TableInfoModal.tsx
@@ -36,11 +36,15 @@ const TableInfoModal = ({
 		setTempSelectedTableName(e.target.value)
 	}
 
-	const capitaliseTableName = () => {
-		const capitalisedTableName =
-			tempSelectedTableName.charAt(0).toUpperCase() +
-			tempSelectedTableName.slice(1)
-		return capitalisedTableName
+	const formatTableName = () => {
+		const parts = tempSelectedTableName.split(" ")
+		const formattedParts = parts.map((part) => {
+			if (part) {
+				return part.charAt(0).toUpperCase() + part.slice(1).toLowerCase()
+			}
+			return part
+		})
+		return formattedParts.join(" ").trim()
 	}
 
 	const toggleStudent = (selectedStudentName: string) => {
@@ -64,7 +68,7 @@ const TableInfoModal = ({
 		e.preventDefault()
 
 		try {
-			const tableName = capitaliseTableName()
+			const tableName = formatTableName()
 			const existingTableName = studentData.find(
 				(student) => student.tableData?.tableName === tableName
 			)
@@ -183,8 +187,8 @@ const TableInfoModal = ({
 									>
 										<input
 											onChange={() => toggleStudent(student.name)}
-											type="checkbox"
 											checked={student.tableData.isOnTable}
+											type="checkbox"
 											id={student.name}
 											name={student.name}
 											className="hidden peer"

--- a/src/components/classroom/studentGrid/AddStudent.tsx
+++ b/src/components/classroom/studentGrid/AddStudent.tsx
@@ -31,12 +31,19 @@ const AddStudent = ({
 	const dateInputRef = useRef<HTMLInputElement>(null)
 
 	const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-		const inputName = e.target.value.trim()
+		const inputName = e.target.value
 		setStudentName(inputName)
 	}
 
-	const capitaliseStudentName = () => {
-		return studentName.charAt(0).toUpperCase() + studentName.slice(1)
+	const formatStudentName = () => {
+		const parts = studentName.split(" ")
+		const formattedParts = parts.map((part) => {
+			if (part) {
+				return part.charAt(0).toUpperCase() + part.slice(1).toLowerCase()
+			}
+			return part
+		})
+		return formattedParts.join(" ").trim()
 	}
 
 	const checkForDuplicates = (
@@ -55,7 +62,7 @@ const AddStudent = ({
 		const uuid = crypto.randomUUID()
 
 		const newStudent = {
-			name: capitaliseStudentName(),
+			name: formatStudentName(),
 			dob: studentDob,
 			points: 0,
 			avatar: avatars[randomIndex],
@@ -70,7 +77,7 @@ const AddStudent = ({
 		}
 
 		const isDuplicate = checkForDuplicates(
-			studentName,
+			newStudent.name,
 			addedStudents,
 			studentData
 		)
@@ -149,7 +156,7 @@ const AddStudent = ({
 
 				{/* Full-screen container to center the panel */}
 				<div className="fixed inset-0 flex items-center justify-center p-4">
-					<Dialog.Panel className="w-full max-w-[500px] h-full max-h-[680px] rounded-xl bg-modalBgClr border-2 border-modalBorderClr overflow-auto">
+					<Dialog.Panel className="w-full max-w-[500px] h-full max-h-[685px] rounded-xl bg-modalBgClr border-2 border-modalBorderClr overflow-auto">
 						<div className="p-5 flex justify-between items-center border-b-2 border-gray-300">
 							<Dialog.Title className="font-bold text-xl capitalize">
 								Add student
@@ -178,6 +185,7 @@ const AddStudent = ({
 								)}
 								<input
 									onChange={handleInputChange}
+									value={studentName}
 									onKeyDown={(e) => {
 										if (e.key === "Enter") {
 											e.preventDefault() // Prevent form submission
@@ -208,6 +216,7 @@ const AddStudent = ({
 								</div>
 								<input
 									onChange={(e) => setStudentDob(e.target.value)}
+									value={studentDob}
 									onKeyDown={(e) => {
 										if (e.key === "Enter") {
 											e.preventDefault() // Prevent form submission

--- a/src/components/classroom/studentGrid/CopyPasteStudentList.tsx
+++ b/src/components/classroom/studentGrid/CopyPasteStudentList.tsx
@@ -36,11 +36,17 @@ const CopyPasteStudentList = ({
 
 	const extractValidStudentNames = (pastedText: string) => {
 		const studentNames = pastedText
-			.split("\n") // split strings into array based on being on a new line
-			.map(
-				(name: string) =>
-					name.charAt(0).toUpperCase() + name.slice(1).toLowerCase().trim()
-			)
+			.split("\n") // split strings into an array based on being on a new line
+			.map((name: string) => {
+				const formattedName = name
+					.trim()
+					.split(" ")
+					.map(
+						(part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase()
+					)
+					.join(" ")
+				return formattedName
+			})
 
 		return filterExtractedNames(studentNames)
 	}
@@ -136,7 +142,7 @@ const CopyPasteStudentList = ({
 
 			{/* Full-screen container to center the panel */}
 			<div className="fixed inset-0 flex items-center justify-center p-4">
-				<Dialog.Panel className="w-full max-w-[650px] h-full max-h-[740px] rounded-xl bg-modalBgClr border-2 border-modalBorderClr overflow-auto">
+				<Dialog.Panel className="w-full max-w-[650px] h-full max-h-[745px] rounded-xl bg-modalBgClr border-2 border-modalBorderClr overflow-auto">
 					<div className="p-5 flex justify-between items-center border-b-2 border-gray-300">
 						<Dialog.Title className="font-bold text-xl capitalize">
 							Copy/Paste student list
@@ -170,6 +176,7 @@ const CopyPasteStudentList = ({
 						)}
 						<textarea
 							onChange={handleTextareaChange}
+							value={pastedText}
 							ref={pasteTextAreaRef}
 							id="pasteNames"
 							rows={10}

--- a/src/components/classroom/tableGrid/AddTable.tsx
+++ b/src/components/classroom/tableGrid/AddTable.tsx
@@ -22,6 +22,11 @@ const AddTable = ({
 	const [tableName, setTableName] = useState("")
 	const tableInputRef = useRef<HTMLInputElement>(null)
 
+	const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		const inputName = e.target.value
+		setTableName(inputName)
+	}
+
 	const toggleSelectedStudent = async (
 		e: React.ChangeEvent<HTMLInputElement>
 	) => {
@@ -56,13 +61,20 @@ const AddTable = ({
 		}
 	}
 
-	const capitaliseTableName = () => {
-		return tableName.charAt(0).toUpperCase() + tableName.slice(1).trim()
+	const formatTableName = () => {
+		const parts = tableName.split(" ")
+		const formattedParts = parts.map((part) => {
+			if (part) {
+				return part.charAt(0).toUpperCase() + part.slice(1).toLowerCase()
+			}
+			return part
+		})
+		return formattedParts.join(" ").trim()
 	}
 
 	const checkExistingTable = () => {
 		return studentData.find(
-			(student) => student.tableData.tableName === capitaliseTableName()
+			(student) => student.tableData.tableName === formatTableName()
 		)
 	}
 
@@ -83,7 +95,7 @@ const AddTable = ({
 						...student,
 						tableData: {
 							...student.tableData,
-							tableName: capitaliseTableName(),
+							tableName: formatTableName(),
 							isOnTable: true,
 							selected: false
 						}
@@ -177,7 +189,7 @@ const AddTable = ({
 									</label>
 								)}
 								<input
-									onChange={(e) => setTableName(e.target.value)}
+									onChange={handleInputChange}
 									value={tableName}
 									type="text"
 									id="tableName"


### PR DESCRIPTION
fix: users can no longer add duplicate student/table group names

prior to fix: users could add duplicate names by inputting the name in lowercase or by putting white space before, after or between the characters.